### PR TITLE
Expose a container Factory 

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,6 +47,9 @@ Data Types
 
 .. autoclass:: hl7.Component
 
+.. autoclass:: hl7.Factory
+   :members:
+
 
 MLLP Network Client
 -------------------

--- a/hl7/__init__.py
+++ b/hl7/__init__.py
@@ -17,14 +17,14 @@ __copyright__ = 'Copyright 2011, John Paulett <john -at- paulett.org>'
 NULL = '""'
 
 from .parser import parse
-from .containers import Sequence, Container, Message, Segment, Field, Repetition, Component
+from .containers import Sequence, Container, Message, Segment, Field, Repetition, Component, Factory
 from .accessor import Accessor
 from .util import ishl7, isfile, split_file, generate_message_control_id
 from .datatypes import parse_datetime
 
 __all__ = [
     "parse",
-    "Sequence", "Container", "Message", "Segment", "Field", "Repetition", "Component",
+    "Sequence", "Container", "Message", "Segment", "Field", "Repetition", "Component", "Factory",
     "Accessor",
     "ishl7", "isfile", "split_file", "generate_message_control_id",
     "parse_datetime",

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -81,3 +81,52 @@ class MessageTest(unittest.TestCase):
         self.assertEqual('python', ack2['MSH.3'])
         self.assertEqual('test', ack2['MSH.4'])
         self.assertNotEqual(ack['MSH.10'], ack2['MSH.10'])
+
+
+class TestMessage(hl7.Message):
+    pass
+
+
+class TestSegment(hl7.Segment):
+    pass
+
+
+class TestField(hl7.Field):
+    pass
+
+
+class TestRepetition(hl7.Repetition):
+    pass
+
+
+class TestComponent(hl7.Component):
+    pass
+
+
+class TestFactory(hl7.Factory):
+    create_message = TestMessage
+    create_segment = TestSegment
+    create_field = TestField
+    create_repetition = TestRepetition
+    create_component = TestComponent
+
+
+class FactoryTest(unittest.TestCase):
+    def test_parse(self):
+        msg = hl7.parse(sample_hl7, factory=TestFactory)
+        self.assertIsInstance(msg, TestMessage)
+        s = msg.segments('OBX')
+        self.assertIsInstance(s[0], TestSegment)
+        self.assertIsInstance(s[0](3), TestField)
+        self.assertIsInstance(s[0](3)(1), TestRepetition)
+        self.assertIsInstance(s[0](3)(1)(1), TestComponent)
+        self.assertEqual("1554-5", s[0](3)(1)(1)(1))
+
+    def test_ack(self):
+        msg = hl7.parse(sample_hl7, factory=TestFactory)
+        ack = msg.create_ack()
+        self.assertIsInstance(ack, TestMessage)
+        self.assertIsInstance(ack(1)(9), TestField)
+        self.assertIsInstance(ack(1)(9)(1), TestRepetition)
+        self.assertIsInstance(ack(1)(9)(1)(2), TestComponent)
+        self.assertEqual("R01", ack(1)(9)(1)(2)(1))


### PR DESCRIPTION
This exposes a Factory the user can supply to control so the parser will use the users Container subclasses when constructing a message.

Let me know what you think. The use-case I'm thinking of is some custom serialization (e.g. to JSON) where I want each container instance to expose a `jsonify` method and Message iterates over it's Fields and invokes `jsonify` and Field.jsonify recursively calls `jsonify` on it's Repetitions and Components and so on. So I need hl7 to construct the Message using my subclasses of each container type.