### PR TITLE
Explicitly convert message from byte to string.

### DIFF
--- a/hl7/client.py
+++ b/hl7/client.py
@@ -91,7 +91,7 @@ class MLLPClient(object):
 
 # wrappers to make testing easier
 def stdout(content):
-    sys.stdout.write(content + b'\n')
+    sys.stdout.write(str(content) + '\n')
 
 
 def stdin():


### PR DESCRIPTION
Unlike Python 2, Python 3 will not implicitly convert a byte to a str when a byte is concatenated with a str. Thanks for the code, by the way.