### PR TITLE
Updated string converters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage.xml
 /dist/
 /env/
 /.eggs/
+.vscode

--- a/hl7/containers.py
+++ b/hl7/containers.py
@@ -587,6 +587,9 @@ class Message(Container):
 
         return ack
 
+    def __str__(self):
+        return super(Message, self).__str__() + self.separator
+
 
 class Segment(Container):
     """Second level of an HL7 message, which represents an HL7 Segment.
@@ -608,7 +611,7 @@ class Segment(Container):
                 + str(self[1])
                 + self.separator.join((str(x) for x in self[3:]))
             )
-        return self.separator.join((str(x) for x in self))
+        return super(Segment, self).__str__()
 
 
 class Field(Container):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -65,7 +65,7 @@ class MLLPClientTest(TestCase):
         self.assertEqual(result, "thanks")
 
         self.client.socket.send.assert_called_once_with(
-            b"\x0bMSH|^~\\&|GHH LAB|ELAB\x1c\x0d"
+            b"\x0bMSH|^~\\&|GHH LAB|ELAB\r\x1c\x0d"
         )
 
     def test_context_manager(self):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -17,7 +17,7 @@ class ConstructionTest(TestCase):
         response = hl7.Message(CR_SEP, [MSH, MSA])
         response["MSH.F1.R1"] = SEP[0]
         response["MSH.F2.R1"] = SEP[1:]
-        self.assertEqual(str(response), "MSH|^~\\&|\rMSA")
+        self.assertEqual(str(response), "MSH|^~\\&|\rMSA\r")
 
     def test_append(self):
         # Append a segment to a message
@@ -27,7 +27,7 @@ class ConstructionTest(TestCase):
         response["MSH.F2.R1"] = SEP[1:]
         MSA = hl7.Segment(SEP[0], [hl7.Field(SEP[1], ["MSA"])])
         response.append(MSA)
-        self.assertEqual(str(response), "MSH|^~\\&|\rMSA")
+        self.assertEqual(str(response), "MSH|^~\\&|\rMSA\r")
 
     def test_append_from_source(self):
         # Copy a segment between messages
@@ -36,7 +36,7 @@ class ConstructionTest(TestCase):
         response = hl7.Message(CR_SEP, [MSH, MSA])
         response["MSH.F1.R1"] = SEP[0]
         response["MSH.F2.R1"] = SEP[1:]
-        self.assertEqual(str(response), "MSH|^~\\&|\rMSA")
+        self.assertEqual(str(response), "MSH|^~\\&|\rMSA\r")
         src_msg = hl7.parse(rep_sample_hl7)
         PID = src_msg["PID"][0]
         self.assertEqual(
@@ -46,5 +46,5 @@ class ConstructionTest(TestCase):
         response.append(PID)
         self.assertEqual(
             str(response),
-            "MSH|^~\\&|\rMSA\rPID|Field1|Component1^Component2|Component1^Sub-Component1&Sub-Component2^Component3|Repeat1~Repeat2",
+            "MSH|^~\\&|\rMSA\rPID|Field1|Component1^Component2|Component1^Sub-Component1&Sub-Component2^Component3|Repeat1~Repeat2\r",
         )

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -10,7 +10,7 @@ from .samples import sample_hl7
 class ContainerTest(TestCase):
     def test_unicode(self):
         msg = hl7.parse(sample_hl7)
-        self.assertEqual(str(msg), sample_hl7.strip())
+        self.assertEqual(str(msg), sample_hl7)
         self.assertEqual(
             str(msg[3][3]), "1554-5^GLUCOSE^POST 12H CFST:MCNC:PT:SER/PLAS:QN"
         )

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -26,8 +26,8 @@ class ParseTest(TestCase):
         # MSH-9 is the message type
         self.assertEqual(msg[0][9], [[["ORU"], ["R01"]]])
         # Do it twice to make sure text coercion is idempotent
-        self.assertEqual(str(msg), sample_hl7.strip())
-        self.assertEqual(str(msg), sample_hl7.strip())
+        self.assertEqual(str(msg), sample_hl7)
+        self.assertEqual(str(msg), sample_hl7)
 
     def test_bytestring_converted_to_unicode(self):
         msg = hl7.parse(str(sample_hl7))
@@ -55,7 +55,7 @@ class ParseTest(TestCase):
         self.assertIsInstance(msg[3][0][0], str)
 
     def test_nonstandard_separators(self):
-        nonstd = "MSH$%~\\&$GHH LAB\rPID$$$555-44-4444$$EVERYWOMAN%EVE%E%%%L"
+        nonstd = "MSH$%~\\&$GHH LAB\rPID$$$555-44-4444$$EVERYWOMAN%EVE%E%%%L\r"
         msg = hl7.parse(nonstd)
 
         self.assertEqual(str(msg), nonstd)


### PR DESCRIPTION
- Updated the Segment class to use the super string converter by default
- Added a string converter to the Message class to address missing ‘\r’ on the final segment of the message
- added the .vscode settings directory to .gitignore