### PR TITLE
Fixed MSH.2 extraction

### DIFF
--- a/hl7/containers.py
+++ b/hl7/containers.py
@@ -236,7 +236,7 @@ class Message(Container):
         if not isinstance(rep, Repetition):
             # leaf
             if component_num == 1 and subcomponent_num == 1:
-                return self.unescape(rep)
+                return rep if accessor.segment == 'MSH' and accessor.field_num in (1, 2) else self.unescape(rep)
             raise IndexError(
                 "Field reaches leaf node before completing path: {0}".format(
                     accessor.key

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -52,6 +52,18 @@ class MessageTest(TestCase):
         self.assertEqual(s[0][0:3], [["OBX"], ["1"], ["SN"]])
         self.assertEqual(s[1][0:3], [["OBX"], ["2"], ["FN"]])
 
+    def test_MSH_1_field(self):
+        msg = hl7.parse(sample_hl7)
+        f = msg["MSH.1"]
+        self.assertEqual(len(f), 1)
+        self.assertEqual(f, "|")
+
+    def test_MSH_2_field(self):
+        msg = hl7.parse(sample_hl7)
+        f = msg["MSH.2"]
+        self.assertEqual(len(f), 4)
+        self.assertEqual(f, "^~\\&")
+
     def test_get_slice(self):
         msg = hl7.parse(sample_hl7)
         s = msg.segments("OBX")[0]


### PR DESCRIPTION
Extracting MSH.2 from a Message does not return the whole field due to the unescape function call.

Updated to simply return ‘rep’ when the segment is ‘MSH’ and the field_num is 1 or 2, as unescaping is not required for these special fields.