### PR TITLE
Update fields to be use caret as separator by default

### DIFF
--- a/hl7/containers.py
+++ b/hl7/containers.py
@@ -781,7 +781,7 @@ class Field(Container):
     def __init__(
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
-        assert not separator or separator == separators[2]
+        assert not separator or separator == separators[3]
         super(Field, self).__init__(
             separator=separators[3],
             sequence=sequence,

--- a/hl7/containers.py
+++ b/hl7/containers.py
@@ -783,7 +783,7 @@ class Field(Container):
     ):
         assert not separator or separator == separators[2]
         super(Field, self).__init__(
-            separator=separators[2],
+            separator=separators[3],
             sequence=sequence,
             esc=esc,
             separators=separators,


### PR DESCRIPTION
I believe this line is wrong in a very simple way - as mentioned in the comments below Fields are usually separated by `^` but the code defaults to `~` i believe. Apologies, I haven't been using this library too long (~2 hours) so there may be many more related changes but if you're happy to point me in the right direction I will update wherever needed.