### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/accessors.rst
+++ b/docs/accessors.rst
@@ -255,7 +255,7 @@ The escape method returns a 'str' object. The unescape method returns a str obje
 
 **Presentation Characters**
 
-HL7 defines a protocol for encoding presentation characters, These include hightlighting,
+HL7 defines a protocol for encoding presentation characters, These include highlighting,
 and rich text functionality. The API does not currently allow for easy access to the
 escape/unescape logic. You must overwrite the message class escape and unescape methods,
 after parsing the message.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -248,7 +248,7 @@ epub_copyright = u"2011, John Paulett"
 # The format is a list of tuples containing the path and title.
 # epub_pre_files = []
 
-# HTML files shat should be inserted after the pages created by sphinx.
+# HTML files that should be inserted after the pages created by sphinx.
 # The format is a list of tuples containing the path and title.
 # epub_post_files = []
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -164,7 +164,7 @@ syntax:
     True
 
 Since many many types of segments only have a single instance in a message
-(e.g. PID or MSH), :py:meth:`hl7.Message.segment` provides a convienance
+(e.g. PID or MSH), :py:meth:`hl7.Message.segment` provides a convenience
 wrapper around :py:meth:`hl7.Message.segments` that returns the first matching
 :py:class:`hl7.Segment`:
 

--- a/hl7/parser.py
+++ b/hl7/parser.py
@@ -96,7 +96,7 @@ def parse(lines, encoding="utf-8", factory=Factory):
     strmsg = lines.strip()
     # The method for parsing the message
     plan = create_parse_plan(strmsg, factory)
-    # Start spliting the methods based upon the ParsePlan
+    # Start splitting the methods based upon the ParsePlan
     return _split(strmsg, plan)
 
 
@@ -247,7 +247,7 @@ def parse_file(lines, encoding="utf-8", factory=Factory):  # noqa: C901
     batches = []
     messages = []
     in_batch = False
-    # Split the file into lines, reatining the ends
+    # Split the file into lines, retaining the ends
     for line in lines.strip(_HL7_WHITESPACE).splitlines(keepends=True):
         # strip out all whitespace MINUS the '\r'
         line = line.strip(_HL7_WHITESPACE)
@@ -399,7 +399,7 @@ class _ParsePlan(object):
         self.factory = factory
 
     def container(self, data):
-        """Return an instance of the approriate container for the *data*
+        """Return an instance of the appropriate container for the *data*
         as specified by the current plan.
         """
         return self.containers[0](

--- a/tests/backports/unittest/async_case.py
+++ b/tests/backports/unittest/async_case.py
@@ -62,7 +62,7 @@ class IsolatedAsyncioTestCase(TestCase):
         # We intentionally don't add inspect.iscoroutinefunction() check
         # for func argument because there is no way
         # to check for async function reliably:
-        # 1. It can be "async def func()" iself
+        # 1. It can be "async def func()" itself
         # 2. Class can implement "async def __call__()" method
         # 3. Regular "def func()" that returns awaitable object
         self.addCleanup(*(func, *args), **kwargs)


### PR DESCRIPTION
There are small typos in:
- docs/accessors.rst
- docs/conf.py
- docs/index.rst
- hl7/parser.py
- tests/backports/unittest/async_case.py

Fixes:
- Should read `that` rather than `shat`.
- Should read `splitting` rather than `spliting`.
- Should read `retaining` rather than `reatining`.
- Should read `itself` rather than `iself`.
- Should read `highlighting` rather than `hightlighting`.
- Should read `convenience` rather than `convienance`.
- Should read `appropriate` rather than `approriate`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md