### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
     author="John Paulett",
     author_email="john@paulett.org",
     url="http://python-hl7.readthedocs.org",
+    project_urls={
+        "Source": "https://github.com/johnpaulett/python-hl7",
+    },
     license="BSD",
     platforms=["POSIX", "Windows"],
     keywords=[


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)