### PR TITLE
fixed --quiet cli option bug

### DIFF
--- a/hl7/client.py
+++ b/hl7/client.py
@@ -196,7 +196,7 @@ def mllp_send():
     parser.add_option(
         "-q",
         "--quiet",
-        action="store_true",
+        action="store_false",
         dest="verbose",
         default=True,
         help="do not print status messages to stdout",


### PR DESCRIPTION
The --quiet option for the CLI doesn't do anything. The action was "store_true" with a default of true which means even if you add the --quiet option it still prints ACKs to the stdout. I have changed the action to "store_false" so now when you use --quiet it doesn't print the ACKs anymore.