### PR TITLE
Switch client CLI to argparse

### DIFF
--- a/hl7/client.py
+++ b/hl7/client.py
@@ -2,7 +2,7 @@ import io
 import os.path
 import socket
 import sys
-from optparse import OptionParser
+import argparse
 
 import hl7
 
@@ -169,39 +169,40 @@ def mllp_send():
     """Command line tool to send messages to an MLLP server"""
     # set up the command line options
     script_name = os.path.basename(sys.argv[0])
-    parser = OptionParser(usage=script_name + " [options] <server>")
-    parser.add_option(
+    parser = argparse.ArgumentParser(usage=script_name + " [options] <server>")
+
+    parser.add_argument(
         "--version",
         action="store_true",
         dest="version",
         default=False,
         help="print current version and exit",
     )
-    parser.add_option(
+    parser.add_argument(
         "-p",
         "--port",
         action="store",
-        type="int",
+        type=int,
         dest="port",
         default=6661,
         help="port to connect to",
     )
-    parser.add_option(
+    parser.add_argument(
         "-f",
         "--file",
         dest="filename",
         help="read from FILE instead of stdin",
         metavar="FILE",
     )
-    parser.add_option(
+    parser.add_argument(
         "-q",
         "--quiet",
-        action="store_true",
+        action="store_false",
         dest="verbose",
         default=True,
         help="do not print status messages to stdout",
     )
-    parser.add_option(
+    parser.add_argument(
         "--loose",
         action="store_true",
         dest="loose",
@@ -212,8 +213,9 @@ def mllp_send():
             '"MSH|^~\\&|". Requires --file option (no stdin)'
         ),
     )
+    parser.add_argument("server", nargs="?")
 
-    (options, args) = parser.parse_args()
+    options = parser.parse_args()
 
     if options.version:
         import hl7
@@ -221,8 +223,8 @@ def mllp_send():
         stdout(hl7.__version__)
         return
 
-    if len(args) == 1:
-        host = args[0]
+    if options.server is not None:
+        host = options.server
     else:
         # server not present
         parser.print_usage()

--- a/hl7/client.py
+++ b/hl7/client.py
@@ -1,8 +1,8 @@
+import argparse
 import io
 import os.path
 import socket
 import sys
-import argparse
 
 import hl7
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import os
 import socket
-from optparse import Values
+from argparse import Namespace
 from shutil import rmtree
 from tempfile import mkdtemp
 from unittest import TestCase
@@ -107,21 +107,20 @@ class MLLPSendTest(TestCase):
         self.dir = mkdtemp()
         self.write(SB + b"foobar" + EB + CR)
 
-        self.option_values = Values(
-            {
-                "port": 6661,
-                "filename": os.path.join(self.dir, "test.hl7"),
-                "verbose": True,
-                "loose": False,
-                "version": False,
-            }
+        self.option_values = Namespace(
+            port=6661,
+            filename=os.path.join(self.dir, "test.hl7"),
+            verbose=True,
+            loose=False,
+            version=False,
+            server="localhost",
         )
 
-        self.options_patch = patch("hl7.client.OptionParser")
+        self.options_patch = patch("hl7.client.argparse.ArgumentParser")
         option_parser = self.options_patch.start()
         self.mock_options = Mock()
         option_parser.return_value = self.mock_options
-        self.mock_options.parse_args.return_value = (self.option_values, ["localhost"])
+        self.mock_options.parse_args.return_value = self.option_values
 
     def tearDown(self):
         # unpatch

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -254,6 +254,16 @@ class MLLPSendTest(TestCase):
         self.assertFalse(self.mock_socket().connect.called)
         self.mock_stdout.assert_called_once_with(str(hl7_version))
 
+    def test_missing_server(self):
+        self.option_values.server = None
+
+        mllp_send()
+
+        self.assertFalse(self.mock_socket().connect.called)
+        self.mock_options.print_usage.assert_called_once_with()
+        self.mock_stderr().write.assert_called_with("server required\n")
+        self.mock_exit.assert_called_with(1)
+
 
 class FakeStream(object):
     count = 0


### PR DESCRIPTION
## Summary
- migrate from optparse to argparse in `hl7.client`
- update unit tests for argparse

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68436781a594832791e684f24dd3933a