### PR TITLE
Fix timezone formatting bug in _UTCOffset

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,8 @@ Changelog
 * Removed deprecated ``hl7.version`` module; use ``hl7.__version__`` instead.
 * Fixed a bug in `mllp_send --quiet` -- thanks `Spencer Vecile <https://github.com/svecile>`_!
 * Switched formatting and linting from black/isort and flake8 to ``ruff``.
+* Fixed timezone formatting when ``parse_datetime`` created ``_UTCOffset`` with a
+  float value.
 
 
 0.4.5 - March 2022

--- a/hl7/datatypes.py
+++ b/hl7/datatypes.py
@@ -10,8 +10,13 @@ class _UTCOffset(datetime.tzinfo):
     """Fixed offset timezone from UTC."""
 
     def __init__(self, minutes):
-        """``minutes`` is a offset from UTC, negative for west of UTC"""
-        self.minutes = minutes
+        """``minutes`` is an offset from UTC, negative for west of UTC."""
+        # ``minutes`` may be passed in as a float when constructed via
+        # :func:`parse_datetime`.  ``datetime.timedelta`` and formatting of the
+        # timezone name expect an ``int``.  Store the offset as an ``int`` to
+        # avoid producing values like ``-5.00.0`` from ``tzname`` when floats are
+        # used.
+        self.minutes = int(minutes)
 
     def utcoffset(self, dt):
         return datetime.timedelta(minutes=self.minutes)

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -44,3 +44,13 @@ class DatetimeTest(TestCase):
     def test_tz(self):
         self.assertEqual("+0205", _UTCOffset(125).tzname(datetime.utcnow()))
         self.assertEqual("-0410", _UTCOffset(-250).tzname(datetime.utcnow()))
+
+    def test_parse_tzname(self):
+        dt = parse_datetime("201403111412-0500")
+        self.assertEqual("-0500", dt.tzname())
+        dt = parse_datetime("201403111412+0530")
+        self.assertEqual("+0530", dt.tzname())
+
+    def test_utc_offset_float(self):
+        self.assertEqual("-0500", _UTCOffset(-300.0).tzname(datetime.utcnow()))
+        self.assertEqual("+0530", _UTCOffset(330.0).tzname(datetime.utcnow()))


### PR DESCRIPTION
## Summary
- ensure `_UTCOffset` stores offset minutes as an integer
- document timezone formatting fix in changelog
- test timezone parsing and formatting with float offsets

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6843871cde208327b44faaa11d07944b