### PR TITLE
Refactor: remove Python 2 leftovers

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # python-hl7 documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul 12 10:57:30 2011.
@@ -43,8 +42,8 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"python-hl7"
-copyright = u"2011-{}, John Paulett".format(date.today().year)
+project = "python-hl7"
+copyright = "2011-{}, John Paulett".format(date.today().year)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -189,7 +188,7 @@ htmlhelp_basename = "python-hl7doc"
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-    ("index", "python-hl7.tex", u"python-hl7 Documentation", u"John Paulett", "manual"),
+    ("index", "python-hl7.tex", "python-hl7 Documentation", "John Paulett", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -220,16 +219,16 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [("mllp_send", "mllp_send", "MLLP network client", [u"John Paulett"], 1)]
+man_pages = [("mllp_send", "mllp_send", "MLLP network client", ["John Paulett"], 1)]
 
 
 # -- Options for Epub output ---------------------------------------------------
 
 # Bibliographic Dublin Core info.
-epub_title = u"python-hl7"
-epub_author = u"John Paulett"
-epub_publisher = u"John Paulett"
-epub_copyright = u"2011, John Paulett"
+epub_title = "python-hl7"
+epub_author = "John Paulett"
+epub_publisher = "John Paulett"
+epub_copyright = "2011, John Paulett"
 
 # The language of the text. It defaults to the language option
 # or en if the language is not set.

--- a/hl7/__init__.py
+++ b/hl7/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """python-hl7 is a simple library for parsing messages of Health Level 7
 (HL7) version 2.x into Python objects.
 

--- a/hl7/accessor.py
+++ b/hl7/accessor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from collections import namedtuple
 
 
@@ -27,7 +26,7 @@ class Accessor(
         subcomponent_num=None,
     ):
         """Create a new instance of Accessor for *segment*. Index numbers start from 1."""
-        return super(Accessor, cls).__new__(
+        return super().__new__(
             cls,
             segment,
             segment_num,

--- a/hl7/client.py
+++ b/hl7/client.py
@@ -19,7 +19,7 @@ class MLLPException(Exception):
     pass
 
 
-class MLLPClient(object):
+class MLLPClient:
     """
     A basic, blocking, HL7 MLLP client based upon :py:mod:`socket`.
 

--- a/hl7/containers.py
+++ b/hl7/containers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import logging
 
@@ -53,7 +52,7 @@ class Container(Sequence):
         # Initialize the list object, optionally passing in the
         # sequence.  Since list([]) == [], using the default
         # parameter will not cause any issues.
-        super(Container, self).__init__(sequence)
+        super().__init__(sequence)
         self.separator = separator
         self.esc = esc
         self.separators = separators
@@ -125,7 +124,7 @@ class Container(Sequence):
     def __getitem__(self, item):
         # Python slice operator was returning a regular list, not a
         # Container subclass
-        sequence = super(Container, self).__getitem__(item)
+        sequence = super().__getitem__(item)
         if isinstance(item, slice):
             return self.__class__(
                 self.separator,
@@ -136,10 +135,6 @@ class Container(Sequence):
             )
         return sequence
 
-    def __getslice__(self, i, j):
-        # Python 2.x compatibility.  __getslice__ is deprecated, and
-        # we want to wrap the logic from __getitem__ when handling slices
-        return self.__getitem__(slice(i, j))
 
     def __str__(self):
         return self.separator.join((str(x) for x in self))
@@ -158,7 +153,7 @@ class File(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[0]
-        super(File, self).__init__(
+        super().__init__(
             separator=separators[0],
             sequence=sequence,
             esc=esc,
@@ -226,11 +221,11 @@ class File(Container):
                 "Either both header and trailer must be present or neither"
             )
         return (
-            super(File, self).__str__()
+            super().__str__()
             if not self.header
             else str(self.header)
             + self.separator
-            + super(File, self).__str__()
+            + super().__str__()
             + str(self.trailer)
             + self.separator
         )
@@ -249,7 +244,7 @@ class Batch(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[0]
-        super(Batch, self).__init__(
+        super().__init__(
             separator=separators[0],
             sequence=sequence,
             esc=esc,
@@ -317,11 +312,11 @@ class Batch(Container):
                 "Either both header and trailer must be present or neither"
             )
         return (
-            super(Batch, self).__str__()
+            super().__str__()
             if not self.header
             else str(self.header)
             + self.separator
-            + super(Batch, self).__str__()
+            + super().__str__()
             + str(self.trailer)
             + self.separator
         )
@@ -332,7 +327,7 @@ class Message(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[0]
-        super(Message, self).__init__(
+        super().__init__(
             separator=separators[0],
             sequence=sequence,
             esc=esc,
@@ -373,7 +368,7 @@ class Message(Container):
             return self.extract_field(*Accessor.parse_key(key))
         elif isinstance(key, Accessor):
             return self.extract_field(*key)
-        return super(Message, self).__getitem__(key)
+        return super().__getitem__(key)
 
     def __setitem__(self, key, value):
         """Index or accessor assignment.
@@ -396,7 +391,7 @@ class Message(Container):
             return self.assign_field(value, *Accessor.parse_key(key))
         elif isinstance(key, Accessor):
             return self.assign_field(value, *key)
-        return super(Message, self).__setitem__(key, value)
+        return super().__setitem__(key, value)
 
     def segment(self, segment_id):
         """Gets the first segment with the *segment_id* from the parsed
@@ -607,7 +602,7 @@ class Message(Container):
         """
         # Per spec, Message Construction Rules, Section 2.6 (v2.8), Message ends
         # with the carriage return
-        return super(Message, self).__str__() + self.separator
+        return super().__str__() + self.separator
 
 
 class Segment(Container):
@@ -615,7 +610,7 @@ class Segment(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[1]
-        super(Segment, self).__init__(
+        super().__init__(
             separator=separators[1],
             sequence=sequence,
             esc=esc,
@@ -774,7 +769,7 @@ class Segment(Container):
                 + str(self[1])
                 + self.separator.join((str(x) for x in self[3:]))
             )
-        return super(Segment, self).__str__()
+        return super().__str__()
 
 
 class Field(Container):
@@ -782,7 +777,7 @@ class Field(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[2]
-        super(Field, self).__init__(
+        super().__init__(
             separator=separators[2],
             sequence=sequence,
             esc=esc,
@@ -801,7 +796,7 @@ class Repetition(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[3]
-        super(Repetition, self).__init__(
+        super().__init__(
             separator=separators[3],
             sequence=sequence,
             esc=esc,
@@ -819,7 +814,7 @@ class Component(Container):
         self, separator=None, sequence=[], esc="\\", separators="\r|~^&", factory=None
     ):
         assert not separator or separator == separators[4]
-        super(Component, self).__init__(
+        super().__init__(
             separator=separators[4],
             sequence=sequence,
             esc=esc,
@@ -832,7 +827,7 @@ class Component(Container):
     """
 
 
-class Factory(object):
+class Factory:
     """Factory used to create each type of Container.
 
     A subclass can be used to create specialized subclasses of each container.

--- a/hl7/containers.py
+++ b/hl7/containers.py
@@ -135,7 +135,6 @@ class Container(Sequence):
             )
         return sequence
 
-
     def __str__(self):
         return self.separator.join((str(x) for x in self))
 

--- a/hl7/datatypes.py
+++ b/hl7/datatypes.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import math
 import re

--- a/hl7/parser.py
+++ b/hl7/parser.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from string import whitespace
 
 from .containers import Factory
@@ -380,7 +379,7 @@ def create_parse_plan(strmsg, factory=Factory):
     return _ParsePlan(separators[0], separators, containers, esc, factory)
 
 
-class _ParsePlan(object):
+class _ParsePlan:
     """Details on how to parse an HL7 message. Typically this object
     should be created via :func:`hl7.create_parse_plan`
     """

--- a/hl7/util.py
+++ b/hl7/util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import datetime
 import logging
 import random
@@ -194,7 +193,7 @@ def unescape(container, field, app_map=None):  # noqa: C901
                 value = "".join(collecting)
                 collecting = []
                 if not value:
-                    logger.warn(
+                    logger.warning(
                         "Error unescaping value [%s], empty sequence found at %d",
                         field,
                         offset,
@@ -219,7 +218,7 @@ def unescape(container, field, app_map=None):  # noqa: C901
                     value[0] == "C"
                 ):  # Convert to new Single Byte character set : 2.10.2
                     # Two HEX values, first value chooses the character set (ISO-IR), second gives the value
-                    logger.warn(
+                    logger.warning(
                         "Error inline character sets [%s] not implemented, field [%s], offset [%s]",
                         value,
                         field,
@@ -227,7 +226,7 @@ def unescape(container, field, app_map=None):  # noqa: C901
                     )
                 elif value[0] == "M":  # Switch to new Multi Byte character set : 2.10.2
                     # Three HEX values, first value chooses the character set (ISO-IR), rest give the value
-                    logger.warn(
+                    logger.warning(
                         "Error inline character sets [%s] not implemented, field [%s], offset [%s]",
                         value,
                         field,

--- a/tests/samples.py
+++ b/tests/samples.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 # Sample message from HL7 Normative Edition
 # http://healthinfo.med.dal.ca/hl7intro/CDA_R2_normativewebedition/help/v3guide/v3guide.htm#v3gexamples
 sample_hl7 = "\r".join(

--- a/tests/test_accessor.py
+++ b/tests/test_accessor.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 from hl7 import Accessor, Field, Message, Segment

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -279,7 +279,7 @@ class MLLPSendTest(TestCase):
         self.assertFalse(self.mock_stdout.called)
 
 
-class FakeStream(object):
+class FakeStream:
     count = 0
 
     def read(self, buf):

--- a/tests/test_construction.py
+++ b/tests/test_construction.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 import hl7

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 import hl7

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 import hl7

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from unittest import TestCase
 
 import hl7


### PR DESCRIPTION
## Summary
- replace deprecated logger.warn with logger.warning
- confirm __getslice__ removed for Python 3 cleanup

## Testing
- `python -m unittest discover -t . -s tests`
- `make tests`


------
https://chatgpt.com/codex/tasks/task_b_684387d9faac8327b5cc39fe12054636