### PR TITLE
Fix typo in parse plan exception

### DIFF
--- a/hl7/parser.py
+++ b/hl7/parser.py
@@ -345,7 +345,7 @@ def create_parse_plan(strmsg, factory=Factory):
     # Extract the rest of the separators. Defaults used if not present.
     if strmsg[:3] not in ("MSH", "FHS", "BHS"):
         raise ParseException(
-            "First segment is {}, must be one of MHS, FHS or BHS".format(strmsg[:3])
+            "First segment is {}, must be one of MSH, FHS or BHS".format(strmsg[:3])
         )
     sep0 = strmsg[3]
     seps = list(strmsg[3 : strmsg.find(sep0, 4)])

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -451,3 +451,8 @@ class ParsePlanTest(TestCase):
 
         n5 = n4.next()
         self.assertTrue(n5 is None)
+
+    def test_create_parse_plan_invalid_segment(self):
+        with self.assertRaises(ParseException) as cm:
+            hl7.parser.create_parse_plan("PID|^~\\&|GHH LAB")
+        self.assertIn("must be one of MSH, FHS or BHS", cm.exception.args[0])


### PR DESCRIPTION
## Summary
- correct MSH typo in `create_parse_plan`
- test invalid first segment handling

## Testing
- `make lint`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_6845eb34d068832d84040d558438218e