### PR TITLE
Add negative zero offset parsing test

### DIFF
--- a/hl7/datatypes.py
+++ b/hl7/datatypes.py
@@ -1,5 +1,4 @@
 import datetime
-import math
 import re
 
 DTM_TZ_RE = re.compile(r"(\d+(?:\.\d+)?)(?:([+-]\d{2})(\d{2}))?")
@@ -16,6 +15,14 @@ class _UTCOffset(datetime.tzinfo):
         # avoid producing values like ``-5.00.0`` from ``tzname`` when floats are
         # used.
         self.minutes = int(minutes)
+
+    def __eq__(self, other):
+        if isinstance(other, _UTCOffset):
+            return self.minutes == other.minutes
+        return NotImplemented
+
+    def __hash__(self):
+        return hash(self.minutes)
 
     def utcoffset(self, dt):
         return datetime.timedelta(minutes=self.minutes)
@@ -49,8 +56,9 @@ def parse_datetime(value):
     tzh = dt_match.group(2)
     tzm = dt_match.group(3)
     if tzh and tzm:
+        sign = -1 if tzh.startswith("-") else 1
         minutes = int(tzh) * 60
-        minutes += math.copysign(int(tzm), minutes)
+        minutes += sign * int(tzm)
         tzinfo = _UTCOffset(minutes)
     else:
         tzinfo = None

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -54,3 +54,7 @@ class DatetimeTest(TestCase):
     def test_utc_offset_float(self):
         self.assertEqual("-0500", _UTCOffset(-300.0).tzname(datetime.utcnow()))
         self.assertEqual("+0530", _UTCOffset(330.0).tzname(datetime.utcnow()))
+
+    def test_parse_negative_zero_offset(self):
+        dt = parse_datetime("201403111412-0030")
+        self.assertEqual(dt.tzinfo, _UTCOffset(-30))

--- a/tests/test_datetime.py
+++ b/tests/test_datetime.py
@@ -58,3 +58,14 @@ class DatetimeTest(TestCase):
     def test_parse_negative_zero_offset(self):
         dt = parse_datetime("201403111412-0030")
         self.assertEqual(dt.tzinfo, _UTCOffset(-30))
+
+    def test_utcoffset_equality(self):
+        self.assertEqual(_UTCOffset(60), _UTCOffset(60))
+        self.assertNotEqual(_UTCOffset(60), _UTCOffset(-60))
+        self.assertNotEqual(_UTCOffset(60), 60)
+
+    def test_utcoffset_hash(self):
+        a = _UTCOffset(45)
+        b = _UTCOffset(45)
+        self.assertEqual(hash(a), hash(b))
+        self.assertEqual(len({a, b}), 1)


### PR DESCRIPTION
## Summary
- add equality helpers to `_UTCOffset`
- handle `-0030` offsets correctly in `parse_datetime`
- test negative zero-hour timezone offset

## Testing
- `make lint`
- `make tests`

------
https://chatgpt.com/codex/tasks/task_e_68461b29c16c832da5cc0d9c00f4b187